### PR TITLE
Make Fortnite weapon stat viewer correctly account for headshot damage cap

### DIFF
--- a/FModel/Creator/Bases/FN/BaseIconStats.cs
+++ b/FModel/Creator/Bases/FN/BaseIconStats.cs
@@ -92,9 +92,16 @@ namespace FModel.Creator.Bases.FN
                         _statistics.Add(new IconStat(Utils.GetLocalizedResource("", "35D04D1B45737BEA25B69686D9E085B9", "Damage"), dmgPb * multiplier, 200));
                     }
 
-                    if (weaponRowValue.TryGetValue(out float dmgCritical, "DamageZone_Critical"))
+                    if (weaponRowValue.TryGetValue(out float mdpc, "MaxDamagePerCartridge") && weaponRowValue.TryGetValue(out int bpc2, "BulletsPerCartridge") && weaponRowValue.TryGetValue(out float DamageZone_Critical, "DamageZone_Critical"))
                     {
-                        _statistics.Add(new IconStat(Utils.GetLocalizedResource("", "0DEF2455463B008C4499FEA03D149EDF", "Headshot Damage"), dmgPb * dmgCritical * multiplier, 200));
+                        if (mdpc == -1)
+                        {
+                            _statistics.Add(new IconStat(Utils.GetLocalizedResource("", "0DEF2455463B008C4499FEA03D149EDF", "Headshot Damage"), dmgPb * DamageZone_Critical * (bpc2 != 0f ? bpc2 : 1), 200));
+                        }
+                        else
+                        {
+                            _statistics.Add(new IconStat(Utils.GetLocalizedResource("", "0DEF2455463B008C4499FEA03D149EDF", "Headshot Damage"), mdpc, 200));
+                        }
                     }
                 }
 

--- a/FModel/Creator/Bases/FN/BaseIconStats.cs
+++ b/FModel/Creator/Bases/FN/BaseIconStats.cs
@@ -84,14 +84,25 @@ namespace FModel.Creator.Bases.FN
                 weaponStatHandle.TryGetValue(out UDataTable dataTable, "DataTable") &&
                 dataTable.TryGetDataTableRow(weaponRowName.Text, StringComparison.OrdinalIgnoreCase, out var weaponRowValue))
             {
-                if (weaponRowValue.TryGetValue(out float dmgPb, "DmgPB") && dmgPb != 0f && weaponRowValue.TryGetValue(out int bpc , "BulletsPerCartridge"))
+                if (weaponRowValue.TryGetValue(out int bpc, "BulletsPerCartridge"))
                 {
-                    _statistics.Add(new IconStat(Utils.GetLocalizedResource("", "35D04D1B45737BEA25B69686D9E085B9", "Damage"), dmgPb * (bpc != 0f ? bpc : 1), 200));
-                }
+                    var multiplier = bpc != 0f ? bpc : 1;
+                    if (weaponRowValue.TryGetValue(out float dmgPb, "DmgPB") && dmgPb != 0f)
+                    {
+                        _statistics.Add(new IconStat(Utils.GetLocalizedResource("", "35D04D1B45737BEA25B69686D9E085B9", "Damage"), dmgPb * multiplier, 200));
+                    }
 
-                if (weaponRowValue.TryGetValue(out int bpc2, "BulletsPerCartridge") && weaponRowValue.TryGetValue(out float DamageZone_Critical, "DamageZone_Critical"))
-                {
-                    _statistics.Add(new IconStat(Utils.GetLocalizedResource("", "0DEF2455463B008C4499FEA03D149EDF", "Headshot Damage"), dmgPb * DamageZone_Critical * (bpc2 != 0f ? bpc2 : 1), 200));
+                    if (weaponRowValue.TryGetValue(out float mdpc, "MaxDamagePerCartridge") && weaponRowValue.TryGetValue(out int bpc2, "BulletsPerCartridge") && weaponRowValue.TryGetValue(out float DamageZone_Critical, "DamageZone_Critical"))
+                    {
+                        if (mdpc == -1)
+                        {
+                            _statistics.Add(new IconStat(Utils.GetLocalizedResource("", "0DEF2455463B008C4499FEA03D149EDF", "Headshot Damage"), dmgPb * DamageZone_Critical * (bpc2 != 0f ? bpc2 : 1), 200));
+                        }
+                        else
+                        {
+                            _statistics.Add(new IconStat(Utils.GetLocalizedResource("", "0DEF2455463B008C4499FEA03D149EDF", "Headshot Damage"), mdpc, 200));
+                        }
+                    }
                 }
 
                 if (weaponRowValue.TryGetValue(out int clipSize, "ClipSize") && clipSize != 0)


### PR DESCRIPTION
In 20.30 a headshot damage cap was added, this prevents shotguns from doing beyond a certain damage amount. On weapons without a cap it is set to -1, so this code checks if it is -1 and determines what to show for the headshot damage based off that.