### PR TITLE
Auto Detection for Tower of Fantasy

### DIFF
--- a/FModel/Enums.cs
+++ b/FModel/Enums.cs
@@ -92,7 +92,9 @@ public enum FGame
     [Description("Sea of Thieves")]
     Athena,
     [Description("Your Beloved ™ Panda")]
-    PandaGame
+    PandaGame,
+    [Description("Tower of Fantasy")]
+    Hotta,
 }
 
 public enum ELoadingMode

--- a/FModel/Settings/UserSettings.cs
+++ b/FModel/Settings/UserSettings.cs
@@ -283,7 +283,8 @@ namespace FModel.Settings
             {FGame.PortalWars, Constants._NO_PRESET_TRIGGER},
             {FGame.Gameface, Constants._NO_PRESET_TRIGGER},
             {FGame.Athena, Constants._NO_PRESET_TRIGGER},
-            {FGame.PandaGame, Constants._NO_PRESET_TRIGGER}
+            {FGame.PandaGame, Constants._NO_PRESET_TRIGGER},
+            {FGame.Hotta, Constants._NO_PRESET_TRIGGER},
         };
         public IDictionary<FGame, string> Presets
         {
@@ -312,7 +313,8 @@ namespace FModel.Settings
             {FGame.PortalWars, EGame.GAME_UE4_LATEST},
             {FGame.Gameface, EGame.GAME_GTATheTrilogyDefinitiveEdition},
             {FGame.Athena, EGame.GAME_SeaOfThieves},
-            {FGame.PandaGame, EGame.GAME_UE4_26}
+            {FGame.PandaGame, EGame.GAME_UE4_26},
+            {FGame.Hotta, EGame.GAME_TowerOfFantasy}
         };
         public IDictionary<FGame, EGame> OverridedGame
         {
@@ -341,7 +343,8 @@ namespace FModel.Settings
             {FGame.PortalWars, null},
             {FGame.Gameface, null},
             {FGame.Athena, null},
-            {FGame.PandaGame, null}
+            {FGame.PandaGame, null},
+            {FGame.Hotta, null},
         };
         public IDictionary<FGame, List<FCustomVersion>> OverridedCustomVersions
         {
@@ -370,7 +373,8 @@ namespace FModel.Settings
             {FGame.PortalWars, null},
             {FGame.Gameface, null},
             {FGame.Athena, null},
-            {FGame.PandaGame, null}
+            {FGame.PandaGame, null},
+            {FGame.Hotta, null},
         };
         public IDictionary<FGame, Dictionary<string, bool>> OverridedOptions
         {
@@ -405,7 +409,12 @@ namespace FModel.Settings
             {FGame.PortalWars, new FEndpoint[]{new (), new ()}},
             {FGame.Gameface, new FEndpoint[]{new (), new ()}},
             {FGame.Athena, new FEndpoint[]{new (), new ()}},
-            {FGame.PandaGame, new FEndpoint[]{new (), new ()}}
+            {FGame.PandaGame, new FEndpoint[]{new (), new ()}},
+            {FGame.Hotta, new []
+                {
+                    new FEndpoint("https://shimizu-izumi.github.io/fmodel/api/v1/aes/hotta.json", "$.['mainKey']")
+                }
+            }
         };
         public IDictionary<FGame, FEndpoint[]> CustomEndpoints
         {
@@ -482,6 +491,7 @@ namespace FModel.Settings
             {FGame.Gameface, new List<CustomDirectory>()},
             {FGame.Athena, new List<CustomDirectory>()},
             {FGame.PandaGame, new List<CustomDirectory>()},
+            {FGame.Hotta, new List<CustomDirectory>()},
         };
         public IDictionary<FGame, IList<CustomDirectory>> CustomDirectories
         {

--- a/FModel/Settings/UserSettings.cs
+++ b/FModel/Settings/UserSettings.cs
@@ -410,11 +410,7 @@ namespace FModel.Settings
             {FGame.Gameface, new FEndpoint[]{new (), new ()}},
             {FGame.Athena, new FEndpoint[]{new (), new ()}},
             {FGame.PandaGame, new FEndpoint[]{new (), new ()}},
-            {FGame.Hotta, new []
-                {
-                    new FEndpoint("https://shimizu-izumi.github.io/fmodel/api/v1/aes/hotta.json", "$.['mainKey']")
-                }
-            }
+            {FGame.Hotta, new FEndpoint[]{new (), new ()}},
         };
         public IDictionary<FGame, FEndpoint[]> CustomEndpoints
         {

--- a/FModel/ViewModels/GameSelectorViewModel.cs
+++ b/FModel/ViewModels/GameSelectorViewModel.cs
@@ -120,6 +120,7 @@ public class GameSelectorViewModel : ViewModel
         yield return GetRockstarGamesGame("GTA III - Definitive Edition", "\\Gameface\\Content\\Paks");
         yield return GetRockstarGamesGame("GTA San Andreas - Definitive Edition", "\\Gameface\\Content\\Paks");
         yield return GetRockstarGamesGame("GTA Vice City - Definitive Edition", "\\Gameface\\Content\\Paks");
+        yield return GetLevelInfiniteGame("tof_launcher", "\\Hotta\\Content\\Paks");
     }
 
     private LauncherInstalled _launcherInstalled;
@@ -194,6 +195,28 @@ public class GameSelectorViewModel : ViewModel
 
         if (!string.IsNullOrEmpty(installLocation))
             return new DetectedGame { GameName = key, GameDirectory = $"{installLocation}{pakDirectory}" };
+
+        Log.Warning("Could not find {GameName} in the registry", key);
+        return null;
+    }
+
+    private DetectedGame GetLevelInfiniteGame(string key, string pakDirectory)
+    {
+        var installLocation = string.Empty;
+        var displayName = string.Empty;
+
+        try
+        {
+            installLocation = App.GetRegistryValue($@"Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{key}", "GameInstallPath", RegistryHive.CurrentUser);
+            displayName = App.GetRegistryValue($@"Software\Microsoft\Windows\CurrentVersion\Uninstall\{key}", "DisplayName", RegistryHive.CurrentUser);
+        }
+        catch
+        {
+            // ignored
+        }
+
+        if (!string.IsNullOrEmpty(installLocation))
+            return new DetectedGame { GameName = displayName, GameDirectory = $"{installLocation}{pakDirectory}" };
 
         Log.Warning("Could not find {GameName} in the registry", key);
         return null;


### PR DESCRIPTION
I added auto-detection for the standalone launcher version of Tower of Fantasy, I also added custom endpoints but they are a bit buggy because I read the AES key from a JSON file, and because of that you always get the error in the image below when you select Tower of Fantasy. I also added a function to detect other games from Level Infinite that use a slightly modified version of the launcher.

Note: The Tower of Fantasy launcher is a modified version of the SYNCED: Off-Planet launcher.

![image](https://user-images.githubusercontent.com/53613583/190160606-140946a6-eceb-42f8-ba0c-762e80e4f21a.png)
