### PR TITLE
Exit gracefully if no game is selected during first-time setup

### DIFF
--- a/FModel/ViewModels/ApplicationViewModel.cs
+++ b/FModel/ViewModels/ApplicationViewModel.cs
@@ -73,6 +73,12 @@ public class ApplicationViewModel : ViewModel
         LoadingModes = new LoadingModesViewModel();
 
         AvoidEmptyGameDirectoryAndSetEGame(false);
+        if (UserSettings.Default.GameDirectory is null)
+        {
+            //If no game is selected, many things will break before a shutdown request is processed in the normal way.
+            //A hard exit is preferable to an unhandled expection in this case
+            Environment.Exit(0);
+        }
         CUE4Parse = new CUE4ParseViewModel(UserSettings.Default.GameDirectory);
         CustomDirectories = new CustomDirectoriesViewModel(CUE4Parse.Game, UserSettings.Default.GameDirectory);
         SettingsView = new SettingsViewModel(CUE4Parse.Game);


### PR DESCRIPTION
Currently, if FModel is opened for the first time, and the user exits out of the game selector without selecting a game, an unhandled exception occurs. 

This fixes that, and simply quits the app, which is the expected behavior.