### PR TITLE
Fix exception when closing tab without an associated file name

### DIFF
--- a/FModel/Views/Resources/Controls/AvalonEditor.xaml.cs
+++ b/FModel/Views/Resources/Controls/AvalonEditor.xaml.cs
@@ -223,7 +223,7 @@ public partial class AvalonEditor
 
     private void OnTabClose(object sender, EventArgs eventArgs)
     {
-        if (eventArgs is not TabControlViewModel.TabEventArgs e || e.TabToRemove.Document == null)
+        if (eventArgs is not TabControlViewModel.TabEventArgs e || e.TabToRemove.Document?.FileName == null)
             return;
 
         var fileName = e.TabToRemove.Document.FileName;


### PR DESCRIPTION
When opening audio in the audio player, it also opens a blank editor tab with a null `Document.FileName`. When closing this blank editor tab, an uncaught `ArgumentNullException` occurs due to the aforementioned null filename.

<details><summary>Screenshots</summary>

![image](https://github.com/4sval/FModel/assets/72096833/3ca3b561-ecb8-49f8-9dfd-553f4f203c29)
![image](https://github.com/4sval/FModel/assets/72096833/a055fa73-ddb7-4d96-bfb6-9771a8a74383)

</details> 

```
[20:38:35 ERR] System.ArgumentNullException: Value cannot be null. (Parameter 'key')
   at System.Collections.Generic.Dictionary`2.FindValue(TKey key)
   at System.Collections.Generic.Dictionary`2.ContainsKey(TKey key)
   at FModel.Views.Resources.Controls.AvalonEditor.OnTabClose(Object sender, EventArgs eventArgs) in D:\source\FModel\FModel\Views\Resources\Controls\AvalonEditor.xaml.cs:line 230
   at FModel.ViewModels.TabControlViewModel.<>c__DisplayClass17_0.<RemoveTab>b__0() in D:\source\FModel\FModel\ViewModels\TabControlViewModel.cs:line 408
   at System.Windows.Threading.Dispatcher.Invoke(Action callback, DispatcherPriority priority, CancellationToken cancellationToken, TimeSpan timeout)
   at System.Windows.Threading.Dispatcher.Invoke(Action callback)
   at FModel.ViewModels.TabControlViewModel.RemoveTab(TabItem tab) in D:\source\FModel\FModel\ViewModels\TabControlViewModel.cs:line 393
   at FModel.ViewModels.Commands.TabCommand.Execute(TabItem contextViewModel, Object parameter) in D:\source\FModel\FModel\ViewModels\Commands\TabCommand.cs:line 23
   at System.Threading.Tasks.Task.<>c.<ThrowAsync>b__128_0(Object state)
   at System.Windows.Threading.ExceptionWrapper.InternalRealCall(Delegate callback, Object args, Int32 numArgs)
   at System.Windows.Threading.ExceptionWrapper.TryCatchWhen(Object source, Delegate callback, Object args, Int32 numArgs, Delegate catchHandler)
```

There may be a better solution to this problem, such as not opening the blank editor tab in the first place, but I feel that this is a good start by preventing the uncaught exception from being thrown.