### PR TITLE
Audio player remove improvements

### DIFF
--- a/FModel/Settings/UserSettings.cs
+++ b/FModel/Settings/UserSettings.cs
@@ -307,6 +307,13 @@ namespace FModel.Settings
             set => SetProperty(ref _addAudio, value);
         }
 
+        private Hotkey _removeAudio = new(Key.X);
+        public Hotkey RemoveAudio
+        {
+            get => _removeAudio;
+            set => SetProperty(ref _removeAudio, value);
+        }
+
         private Hotkey _playPauseAudio = new(Key.K);
         public Hotkey PlayPauseAudio
         {

--- a/FModel/ViewModels/AudioPlayerViewModel.cs
+++ b/FModel/ViewModels/AudioPlayerViewModel.cs
@@ -265,6 +265,13 @@ public class AudioPlayerViewModel : ViewModel, ISource, IDisposable
         if (_audioFiles.Count < 1) return;
         Application.Current.Dispatcher.Invoke(() =>
         {
+            var removedPlaying = false;
+            if (PlayedFile.Id == SelectedAudioFile.Id)
+            {
+                removedPlaying = true;
+                Stop();
+            }
+
             _audioFiles.RemoveAt(SelectedAudioFile.Id);
             for (var i = 0; i < _audioFiles.Count; i++)
             {

--- a/FModel/Views/AudioPlayer.xaml.cs
+++ b/FModel/Views/AudioPlayer.xaml.cs
@@ -75,6 +75,8 @@ public partial class AudioPlayer
             _applicationView.AudioPlayer.Previous();
         else if (UserSettings.Default.NextAudio.IsTriggered(e.Key))
             _applicationView.AudioPlayer.Next();
+        else if (UserSettings.Default.RemoveAudio.IsTriggered(e.Key))
+            _applicationView.AudioPlayer.Remove();
     }
 
     private void OnAudioFileMouseDoubleClick(object sender, MouseButtonEventArgs e)

--- a/FModel/Views/Resources/Controls/Aup/SourceEventArgs.cs
+++ b/FModel/Views/Resources/Controls/Aup/SourceEventArgs.cs
@@ -4,7 +4,8 @@ namespace FModel.Views.Resources.Controls.Aup;
 
 public enum ESourceEventType
 {
-    Loading
+    Loading,
+    Clearing
 }
 
 public class SourceEventArgs : EventArgs

--- a/FModel/Views/SettingsView.xaml
+++ b/FModel/Views/SettingsView.xaml
@@ -440,6 +440,7 @@
                         <RowDefinition Height="Auto" />
                         <RowDefinition Height="Auto" />
                         <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
                     </Grid.RowDefinitions>
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="Auto" />
@@ -483,6 +484,9 @@
                     <TextBlock Grid.Row="11" Grid.Column="0" Text="Next Audio" VerticalAlignment="Center" Margin="0 0 0 5" />
                     <controls:HotkeyTextBox Grid.Row="11" Grid.Column="2" Style="{StaticResource TextBoxDefaultStyle}" Margin="0 0 0 5"
                                             HotKey="{Binding NextAudio, Source={x:Static local:Settings.UserSettings.Default}, Mode=TwoWay}" />
+                    <TextBlock Grid.Row="12" Grid.Column="0" Text="Remove Selected Audio" VerticalAlignment="Center" Margin="0 0 0 5" />
+                    <controls:HotkeyTextBox Grid.Row="12" Grid.Column="2" Style="{StaticResource TextBoxDefaultStyle}" Margin="0 0 0 5"
+                                            HotKey="{Binding RemoveAudio, Source={x:Static local:Settings.UserSettings.Default}, Mode=TwoWay}" />
                 </Grid>
             </DataTemplate>
         </ResourceDictionary>


### PR DESCRIPTION
Changes:
- Add <kbd>X</kbd> hotkey for removing the currently selected audio in the audio player.
  - I was a bit conflicted on this choice. I would have preferred <kbd>del</kbd>, but since it is used to clear hotkeys in the settings window, it was not an option. My next choice was <kbd>D</kbd> but I wanted to avoid conflicting hotkeys, even if they were from different windows. Eventually I settled on borrowing Blender's delete key, <kbd>D</kbd>.
- Stop playback if the removed file was the currently playing file
- Clear state related to the currently playing audio if the last audio was removed from the playlist.

If there are any changes you would like made to this PR, please let me know.