### PR TITLE
Add support for ComponentContainer

### DIFF
--- a/FModel/Creator/Bases/FN/BaseIcon.cs
+++ b/FModel/Creator/Bases/FN/BaseIcon.cs
@@ -31,6 +31,7 @@ public class BaseIcon : UCreator
     {
         // rarity
         if (Object.TryGetValue(out FPackageIndex series, "Series")) GetSeries(series);
+        else if (Object.TryGetValue(out FStructFallback componentContainer, "ComponentContainer")) GetSeries(componentContainer);
         else GetRarity(Object.GetOrDefault("Rarity", EFortRarity.Uncommon)); // default is uncommon
 
         // preview
@@ -125,6 +126,21 @@ public class BaseIcon : UCreator
         if (!Utils.TryGetPackageIndexExport(s, out UObject export)) return;
 
         GetSeries(export);
+    }
+
+    private void GetSeries(FStructFallback s)
+    {
+        if (!s.TryGetValue(out FPackageIndex[] components, "Components")) return;
+
+        foreach (var component in components)
+        {
+            if (!component.TryLoad(out var componentObj) ||
+                !componentObj!.TryGetValue(out UObject componentSeriesDef, "Series"))
+                continue;
+
+            GetSeries(componentSeriesDef);
+            break;
+        }
     }
 
     protected void GetSeries(UObject uObject)


### PR DESCRIPTION
In Fortnite 28.30, the Series property was moved around, this adds support for reading the new schema.