### PR TITLE
Implement CodeQL Workflow for Enhanced Security Scanning Across Multiple .NET Versions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,7 +19,7 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.result }}
     steps:
       - id: set-matrix
-        uses: actions/github-script@v7
+      - uses: actions/github-script@v7
         with:
           result-encoding: string
           script: |

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,9 +27,9 @@ jobs:
         with:
           result-encoding: string
           script: |
-            const latestOnly = ${{ github.event.inputs.latestOnly }} == 'true';
+            const latestOnly = "${{ github.event.inputs.latestOnly }}" == 'true';
             const osVersion = latestOnly ? 'windows-latest' : 'windows-2019';
-            const dotnetVersion = ${{ github.event.inputs.dotnetVersion }};
+            const dotnetVersion = "${{ github.event.inputs.dotnetVersion }}";
             const matrix = {
               include: [
                 { os: osVersion, dotnet-version: dotnetVersion || '6.0.x' },
@@ -38,6 +38,7 @@ jobs:
               ]
             };
             return JSON.stringify(matrix);
+
             
   analyze:
     needs: setup_matrix

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -42,14 +42,6 @@ jobs:
       fail-fast: false
       matrix: ${{fromJson(needs.setup_matrix.outputs.matrix)}}
     steps:
-      - name: Check out repository code
-      - uses: actions/checkout@v4
-
-      - name: .NET Setup
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: ${{ matrix.dotnet-version }}
-
       - name: Checkout repository
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,6 +1,10 @@
 name: "CodeQL"
 
 on:
+  push:	
+    branches: [ "master" ]	
+  pull_request:	
+    branches: [ "master" ]
   workflow_dispatch:
     inputs:
       dotnetVersion:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -16,15 +16,16 @@ jobs:
   setup_matrix:
     runs-on: ubuntu-latest
     outputs:
-      matrix: ${{ steps.set-matrix.outputs.matrix }}
+      matrix: ${{ steps.set-matrix.outputs.result }}
     steps:
       - id: set-matrix
         uses: actions/github-script@v7
         with:
+          result-encoding: string
           script: |
-            const dotnetVersion = '${{ github.event.inputs.dotnetVersion }}';
             const latestOnly = ${{ github.event.inputs.latestOnly }} == 'true';
             const osVersion = latestOnly ? 'windows-latest' : 'windows-2019';
+            const dotnetVersion = ${{ github.event.inputs.dotnetVersion }};
             const matrix = {
               include: [
                 { os: osVersion, dotnet-version: dotnetVersion || '6.0.x' },
@@ -32,7 +33,7 @@ jobs:
                 { os: 'windows-latest', dotnet-version: dotnetVersion || '8.0.x' }
               ]
             };
-            core.setOutput('matrix', JSON.stringify(matrix));
+            return JSON.stringify(matrix);
             
   analyze:
     needs: setup_matrix

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,12 +32,13 @@ jobs:
             const dotnetVersion = "${{ github.event.inputs.dotnetVersion }}";
             const matrix = {
               include: [
-                { os: osVersion, dotnet-version: dotnetVersion || '6.0.x' },
-                { os: 'windows-latest', dotnet-version: dotnetVersion || '7.0.x' },
-                { os: 'windows-latest', dotnet-version: dotnetVersion || '8.0.x' }
+                { os: osVersion, 'dotnet-version': dotnetVersion || '6.0.x' },
+                { os: 'windows-latest', 'dotnet-version': dotnetVersion || '7.0.x' },
+                { os: 'windows-latest', 'dotnet-version': dotnetVersion || '8.0.x' }
               ]
             };
             return JSON.stringify(matrix);
+
 
             
   analyze:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,56 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+  workflow_dispatch:
+    inputs:
+        appVersion:
+          description: 'FModel Version And Release Tag'
+          required: false
+          default: '4.4.X.X'
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: 'windows-latest'
+    timeout-minutes: 360
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'csharp' ]
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+          submodules: 'true'
+
+    - name: Fetch Submodules Recursively
+      run: git submodule update --init --recursive
+
+    - name: .NET 6 Setup
+      uses: actions/setup-dotnet@v2
+      with:
+        dotnet-version: '6.0.x'
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v3
+      with:
+        languages: ${{ matrix.language }}
+
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v3
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v3
+      with:
+        category: "/language:${{matrix.language}}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,16 +28,16 @@ jobs:
           result-encoding: string
           script: |
             const latestOnly = "${{ github.event.inputs.latestOnly }}" == 'true';
-            const osVersion = latestOnly ? 'windows-latest' : 'windows-2019';
-            const dotnetVersion = "${{ github.event.inputs.dotnetVersion }}";
-            const matrix = {
-              include: [
-                { os: osVersion, 'dotnet-version': dotnetVersion || '6.0.x' },
-                { os: 'windows-latest', 'dotnet-version': dotnetVersion || '7.0.x' },
-                { os: 'windows-latest', 'dotnet-version': dotnetVersion || '8.0.x' }
-              ]
-            };
+            const dotnetVersions = ["6.0.x", "7.0.x", "8.0.x"];
+            const osVersions = latestOnly ? ['windows-latest'] : ['windows-2019', 'windows-latest'];
+            const matrix = { include: [] };
+            for (const osVersion of osVersions) {
+              for (const dotnetVersion of dotnetVersions) {
+                matrix.include.push({ os: osVersion, 'dotnet-version': dotnetVersion });
+              }
+            }
             return JSON.stringify(matrix);
+
 
 
             

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,56 +1,68 @@
 name: "CodeQL"
 
 on:
-  push:
-    branches: [ "master" ]
-  pull_request:
-    branches: [ "master" ]
   workflow_dispatch:
     inputs:
-        appVersion:
-          description: 'FModel Version And Release Tag'
-          required: false
-          default: '4.4.X.X'
+      dotnetVersion:
+        description: 'Override .NET Version (Default: 6.0.x, 7.0.x, 8.0.x)'
+        required: false
+        default: ''
+      latestOnly:
+        description: 'Scan with only the latest Windows runner (true/false)'
+        required: false
+        default: 'false'
 
 jobs:
-  analyze:
-    name: Analyze
-    runs-on: 'windows-latest'
-    timeout-minutes: 360
-    permissions:
-      security-events: write
-      actions: read
-      contents: read
+  setup_matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - id: set-matrix
+        run: |
+          echo "::set-output name=matrix::${{ toJson({
+            include: [
+              { os: '${{ github.event.inputs.latestOnly == 'true' && 'windows-latest' || 'windows-2019' }}', dotnet-version: ${{ github.event.inputs.dotnetVersion || '6.0.x' }} },
+              { os: '${{ github.event.inputs.latestOnly == 'true' && 'windows-latest' || 'windows-latest' }}', dotnet-version: ${{ github.event.inputs.dotnetVersion || '7.0.x' }} },
+              { os: '${{ github.event.inputs.latestOnly == 'true' && 'windows-latest' || 'windows-latest' }}', dotnet-version: ${{ github.event.inputs.dotnetVersion || '8.0.x' }} }
+            ]
+          })}}"
 
+  analyze:
+    needs: setup_matrix
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
-      matrix:
-        language: [ 'csharp' ]
-
+      matrix: ${{fromJson(needs.setup_matrix.outputs.matrix)}}
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
-      with:
+      - name: Check out repository code
+      - uses: actions/checkout@v4
+
+      - name: .NET Setup
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ matrix.dotnet-version }}
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
           submodules: 'true'
-
-    - name: Fetch Submodules Recursively
-      run: git submodule update --init --recursive
-
-    - name: .NET 6 Setup
-      uses: actions/setup-dotnet@v2
-      with:
-        dotnet-version: '6.0.x'
-
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
-      with:
-        languages: ${{ matrix.language }}
-
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v3
-
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
-      with:
-        category: "/language:${{matrix.language}}"
+  
+      - name: Fetch Submodules Recursively
+        run: git submodule update --init --recursive
+  
+      - name: .NET Setup
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ matrix.dotnet-version }}
+  
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: 'csharp'
+  
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+  
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,14 +20,27 @@ jobs:
     steps:
       - id: set-matrix
         run: |
-          echo "::set-output name=matrix::${{ toJson({
-            include: [
-              { os: '${{ github.event.inputs.latestOnly == 'true' && 'windows-latest' || 'windows-2019' }}', dotnet-version: ${{ github.event.inputs.dotnetVersion || '6.0.x' }} },
-              { os: '${{ github.event.inputs.latestOnly == 'true' && 'windows-latest' || 'windows-latest' }}', dotnet-version: ${{ github.event.inputs.dotnetVersion || '7.0.x' }} },
-              { os: '${{ github.event.inputs.latestOnly == 'true' && 'windows-latest' || 'windows-latest' }}', dotnet-version: ${{ github.event.inputs.dotnetVersion || '8.0.x' }} }
+          MATRIX_JSON=$(cat <<EOF
+          {
+            "include": [
+              {
+                "os": "${{ github.event.inputs.latestOnly == 'true' && 'windows-latest' || 'windows-2019' }}",
+                "dotnet-version": "${{ github.event.inputs.dotnetVersion || '6.0.x' }}"
+              },
+              {
+                "os": "${{ github.event.inputs.latestOnly == 'true' && 'windows-latest' || 'windows-latest' }}",
+                "dotnet-version": "${{ github.event.inputs.dotnetVersion || '7.0.x' }}"
+              },
+              {
+                "os": "${{ github.event.inputs.latestOnly == 'true' && 'windows-latest' || 'windows-latest' }}",
+                "dotnet-version": "${{ github.event.inputs.dotnetVersion || '8.0.x' }}"
+              }
             ]
-          })}}"
-
+          }
+          EOF
+          )
+          echo "::set-output name=matrix::$MATRIX_JSON"
+          
   analyze:
     needs: setup_matrix
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,28 +19,21 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - id: set-matrix
-        run: |
-          MATRIX_JSON=$(cat <<EOF
-          {
-            "include": [
-              {
-                "os": "${{ github.event.inputs.latestOnly == 'true' && 'windows-latest' || 'windows-2019' }}",
-                "dotnet-version": "${{ github.event.inputs.dotnetVersion || '6.0.x' }}"
-              },
-              {
-                "os": "${{ github.event.inputs.latestOnly == 'true' && 'windows-latest' || 'windows-latest' }}",
-                "dotnet-version": "${{ github.event.inputs.dotnetVersion || '7.0.x' }}"
-              },
-              {
-                "os": "${{ github.event.inputs.latestOnly == 'true' && 'windows-latest' || 'windows-latest' }}",
-                "dotnet-version": "${{ github.event.inputs.dotnetVersion || '8.0.x' }}"
-              }
-            ]
-          }
-          EOF
-          )
-          echo "::set-output name=matrix::$MATRIX_JSON"
-          
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const dotnetVersion = '${{ github.event.inputs.dotnetVersion }}';
+            const latestOnly = ${{ github.event.inputs.latestOnly }} == 'true';
+            const osVersion = latestOnly ? 'windows-latest' : 'windows-2019';
+            const matrix = {
+              include: [
+                { os: osVersion, dotnet-version: dotnetVersion || '6.0.x' },
+                { os: 'windows-latest', dotnet-version: dotnetVersion || '7.0.x' },
+                { os: 'windows-latest', dotnet-version: dotnetVersion || '8.0.x' }
+              ]
+            };
+            core.setOutput('matrix', JSON.stringify(matrix));
+            
   analyze:
     needs: setup_matrix
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -18,8 +18,8 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.result }}
     steps:
-      - id: set-matrix
       - uses: actions/github-script@v7
+        id: set-matrix
         with:
           result-encoding: string
           script: |


### PR DESCRIPTION
This pull request introduces the [CodeQL](https://docs.github.com/en/code-security/code-scanning/introduction-to-code-scanning/about-code-scanning-with-codeql) workflow aimed at scanning codebase for vulnerabilities and coding errors. It is configured to test against the three latest .NET versions: 6.0.x, 7.0.x, and 8.0.x.

The workflow is designed to run on two different GitHub Actions runners: windows-2019 and windows-latest (Windows 2022), ensuring comprehensive coverage and compatibility with supported Windows environments. This dual-runner setup allows us to catch issues that may arise from differences between the Windows versions, thereby taking proactive steps to help maintain secure and high-quality code.

Also, it comes with a nifty badge. 😄 
[![CodeQL](https://github.com/DJStompZone/FModel/actions/workflows/codeql.yml/badge.svg)](https://github.com/DJStompZone/FModel/actions/workflows/codeql.yml)