### PR TITLE
Adding texture array handling/previewing

### DIFF
--- a/FModel/ViewModels/TabControlViewModel.cs
+++ b/FModel/ViewModels/TabControlViewModel.cs
@@ -240,18 +240,30 @@ public class TabItem : ViewModel
 
     public void AddImage(UTexture texture, bool save, bool updateUi)
     {
-        var img = texture.Decode(UserSettings.Default.CurrentDir.TexturePlatform);
-        if (texture is UTextureCube)
+        bool appendLayerNumber = false;
+        SKBitmap[] img = new SKBitmap[texture.IsNormalMap ? 1 : texture.GetFirstMip().SizeZ];
+        if (texture is UTexture2DArray textureArray && !texture.IsNormalMap)
         {
-            img = img?.ToPanorama();
+            img = textureArray.DecodeTextureArray(UserSettings.Default.CurrentDir.TexturePlatform);
+            appendLayerNumber = true;
+        }
+        else
+        {
+            img[0] = texture.Decode(UserSettings.Default.CurrentDir.TexturePlatform);
+            if (texture is UTextureCube)
+            {
+                img[0] = img[0]?.ToPanorama();
+            }
         }
 
-        AddImage(texture.Name, texture.RenderNearestNeighbor, img, save, updateUi);
+        AddImage(texture.Name, texture.RenderNearestNeighbor, img, save, updateUi, appendLayerNumber);
     }
 
-    public void AddImage(string name, bool rnn, SKBitmap[] img, bool save, bool updateUi)
+    public void AddImage(string name, bool rnn, SKBitmap[] img, bool save, bool updateUi, bool appendLayerNumber = false)
     {
-        foreach (var i in img) AddImage(name, rnn, i, save, updateUi);
+        var count = 0;
+        foreach (var i in img)
+            AddImage(name + (appendLayerNumber ? "_" + count++ : ""), rnn, i, save, updateUi);
     }
 
     public void AddImage(string name, bool rnn, SKBitmap img, bool save, bool updateUi)


### PR DESCRIPTION
Currently, a few textures in the Fortnite files are stored as UTexture2DArray objects, which pack multiple images into a single image with multiple layers. For example, TA_Atlas_Figure_EyeAndLash_Char01 has 20 different textures packed into that single object.

![343900763-111a6d84-b0d4-4204-90c3-a083ceeec581](https://github.com/4sval/FModel/assets/17242591/a93e93a5-89f7-4ff2-a1bc-b81f2570c98c)

This PR adds handling for UTexture2DArray objects, and allows the user to view and save all layers of an image instead of just the first layer.

![FModelLayers](https://github.com/4sval/FModel/assets/17242591/92b4819e-ed3a-4a0e-9d87-ca508158d813)

Depends on [CUE4Parse PR 145](https://github.com/FabianFG/CUE4Parse/pull/145)