### PR TITLE
Make on-demand download timeout configurable.

### DIFF
--- a/FModel/Framework/FRestRequest.cs
+++ b/FModel/Framework/FRestRequest.cs
@@ -1,11 +1,12 @@
 using System;
+using FModel.Settings;
 using RestSharp;
 
 namespace FModel.Framework;
 
 public class FRestRequest : RestRequest
 {
-    private const int TimeoutSeconds = 5;
+    private int TimeoutSeconds = UserSettings.Default.HttpRequestTimeout;
 
     public FRestRequest(string url, Method method = Method.Get) : base(url, method)
     {

--- a/FModel/Settings/DirectorySettings.cs
+++ b/FModel/Settings/DirectorySettings.cs
@@ -106,6 +106,13 @@ public class DirectorySettings : ViewModel, ICloneable
         set => SetProperty(ref _criwareDecryptionKey, value);
     }
 
+    private uint _onDemandTimeout = 120;
+    public uint OnDemandTimeout
+    {
+        get => Math.Max(_onDemandTimeout, 60);
+        set => SetProperty(ref _onDemandTimeout, Math.Max(_onDemandTimeout, 60));
+    }
+
     private bool Equals(DirectorySettings other)
     {
         return GameDirectory == other.GameDirectory && UeVersion == other.UeVersion;

--- a/FModel/Settings/DirectorySettings.cs
+++ b/FModel/Settings/DirectorySettings.cs
@@ -106,13 +106,6 @@ public class DirectorySettings : ViewModel, ICloneable
         set => SetProperty(ref _criwareDecryptionKey, value);
     }
 
-    private uint _onDemandTimeout = 120;
-    public uint OnDemandTimeout
-    {
-        get => Math.Max(_onDemandTimeout, 60);
-        set => SetProperty(ref _onDemandTimeout, Math.Max(_onDemandTimeout, 60));
-    }
-
     private bool Equals(DirectorySettings other)
     {
         return GameDirectory == other.GameDirectory && UeVersion == other.UeVersion;

--- a/FModel/Settings/UserSettings.cs
+++ b/FModel/Settings/UserSettings.cs
@@ -544,5 +544,12 @@ namespace FModel.Settings
             get => _previewTexturesAssetExplorer;
             set => SetProperty(ref _previewTexturesAssetExplorer, value);
         }
+
+        private int _httpRequestTimeout = 30;
+        public int HttpRequestTimeout
+        {
+            get => _httpRequestTimeout;
+            set => SetProperty(ref _httpRequestTimeout, Math.Max(value, 30));
+        }
     }
 }

--- a/FModel/Settings/UserSettings.cs
+++ b/FModel/Settings/UserSettings.cs
@@ -545,11 +545,11 @@ namespace FModel.Settings
             set => SetProperty(ref _previewTexturesAssetExplorer, value);
         }
 
-        private int _httpRequestTimeout = 30;
+        private int _httpRequestTimeout = 60;
         public int HttpRequestTimeout
         {
             get => _httpRequestTimeout;
-            set => SetProperty(ref _httpRequestTimeout, Math.Max(value, 30));
+            set => SetProperty(ref _httpRequestTimeout, value);
         }
     }
 }

--- a/FModel/ViewModels/CUE4ParseViewModel.cs
+++ b/FModel/ViewModels/CUE4ParseViewModel.cs
@@ -231,7 +231,7 @@ public class CUE4ParseViewModel : ViewModel
             {
                 ChunkHostUri = new Uri("https://download.epicgames.com/", UriKind.Absolute),
                 ChunkCacheDirectory = Directory.CreateDirectory(Path.Combine(UserSettings.Default.OutputDirectory, ".data")),
-                Timeout = TimeSpan.FromSeconds(30)
+                Timeout = TimeSpan.FromSeconds(UserSettings.Default.CurrentDir.OnDemandTimeout)
             };
 
             switch (Provider)

--- a/FModel/ViewModels/CUE4ParseViewModel.cs
+++ b/FModel/ViewModels/CUE4ParseViewModel.cs
@@ -231,7 +231,7 @@ public class CUE4ParseViewModel : ViewModel
             {
                 ChunkHostUri = new Uri("https://download.epicgames.com/", UriKind.Absolute),
                 ChunkCacheDirectory = Directory.CreateDirectory(Path.Combine(UserSettings.Default.OutputDirectory, ".data")),
-                Timeout = TimeSpan.FromSeconds(UserSettings.Default.CurrentDir.OnDemandTimeout)
+                Timeout = TimeSpan.FromSeconds(UserSettings.Default.HttpRequestTimeout)
             };
 
             switch (Provider)

--- a/FModel/ViewModels/SettingsViewModel.cs
+++ b/FModel/ViewModels/SettingsViewModel.cs
@@ -172,6 +172,13 @@ public class SettingsViewModel : ViewModel
         set => SetProperty(ref _criwareDecryptionKey, value);
     }
 
+    private uint _onDemandTimeout = 120;
+    public uint OnDemandTimeout
+    {
+        get => Math.Max(_onDemandTimeout, 60);
+        set => SetProperty(ref _onDemandTimeout, Math.Max(_onDemandTimeout, 60));
+    }
+
     public bool SocketSettingsEnabled => SelectedMeshExportFormat == EMeshFormat.ActorX;
     public bool CompressionSettingsEnabled => SelectedMeshExportFormat == EMeshFormat.UEFormat;
 
@@ -237,6 +244,7 @@ public class SettingsViewModel : ViewModel
         _optionsSnapshot = UserSettings.Default.CurrentDir.Versioning.Options;
         _mapStructTypesSnapshot = UserSettings.Default.CurrentDir.Versioning.MapStructTypes;
         _criwareDecryptionKey = UserSettings.Default.CurrentDir.CriwareDecryptionKey;
+        _onDemandTimeout = UserSettings.Default.CurrentDir.OnDemandTimeout;
 
         AesEndpoint = UserSettings.Default.CurrentDir.Endpoints[0];
         MappingEndpoint = UserSettings.Default.CurrentDir.Endpoints[1];
@@ -273,6 +281,7 @@ public class SettingsViewModel : ViewModel
         SelectedMaterialExportFormat = _materialExportFormatSnapshot;
         SelectedTextureExportFormat = _textureExportFormatSnapshot;
         CriwareDecryptionKey = _criwareDecryptionKey;
+        OnDemandTimeout = _onDemandTimeout;
         SelectedAesReload = UserSettings.Default.AesReload;
         SelectedDiscordRpc = UserSettings.Default.DiscordRpc;
 
@@ -314,7 +323,8 @@ public class SettingsViewModel : ViewModel
         UserSettings.Default.CurrentDir.Versioning.Options = SelectedOptions;
         UserSettings.Default.CurrentDir.Versioning.MapStructTypes = SelectedMapStructTypes;
         UserSettings.Default.CurrentDir.CriwareDecryptionKey = CriwareDecryptionKey;
-
+        UserSettings.Default.CurrentDir.OnDemandTimeout = OnDemandTimeout;
+        
         UserSettings.Default.AssetLanguage = SelectedAssetLanguage;
         UserSettings.Default.CompressedAudioMode = SelectedCompressedAudio;
         UserSettings.Default.CosmeticStyle = SelectedCosmeticStyle;

--- a/FModel/ViewModels/SettingsViewModel.cs
+++ b/FModel/ViewModels/SettingsViewModel.cs
@@ -172,13 +172,6 @@ public class SettingsViewModel : ViewModel
         set => SetProperty(ref _criwareDecryptionKey, value);
     }
 
-    private uint _onDemandTimeout = 120;
-    public uint OnDemandTimeout
-    {
-        get => Math.Max(_onDemandTimeout, 60);
-        set => SetProperty(ref _onDemandTimeout, Math.Max(_onDemandTimeout, 60));
-    }
-
     public bool SocketSettingsEnabled => SelectedMeshExportFormat == EMeshFormat.ActorX;
     public bool CompressionSettingsEnabled => SelectedMeshExportFormat == EMeshFormat.UEFormat;
 
@@ -205,6 +198,7 @@ public class SettingsViewModel : ViewModel
     private string _codeSnapshot;
     private string _modelSnapshot;
     private string _gameSnapshot;
+    private int _httpRequestTimeout;
     private ETexturePlatform _uePlatformSnapshot;
     private EGame _ueGameSnapshot;
     private IList<FCustomVersion> _customVersionsSnapshot;
@@ -238,13 +232,13 @@ public class SettingsViewModel : ViewModel
         _codeSnapshot = UserSettings.Default.CodeDirectory;
         _modelSnapshot = UserSettings.Default.ModelDirectory;
         _gameSnapshot = UserSettings.Default.GameDirectory;
+        _httpRequestTimeout = UserSettings.Default.HttpRequestTimeout;
         _uePlatformSnapshot = UserSettings.Default.CurrentDir.TexturePlatform;
         _ueGameSnapshot = UserSettings.Default.CurrentDir.UeVersion;
         _customVersionsSnapshot = UserSettings.Default.CurrentDir.Versioning.CustomVersions;
         _optionsSnapshot = UserSettings.Default.CurrentDir.Versioning.Options;
         _mapStructTypesSnapshot = UserSettings.Default.CurrentDir.Versioning.MapStructTypes;
         _criwareDecryptionKey = UserSettings.Default.CurrentDir.CriwareDecryptionKey;
-        _onDemandTimeout = UserSettings.Default.CurrentDir.OnDemandTimeout;
 
         AesEndpoint = UserSettings.Default.CurrentDir.Endpoints[0];
         MappingEndpoint = UserSettings.Default.CurrentDir.Endpoints[1];
@@ -281,7 +275,6 @@ public class SettingsViewModel : ViewModel
         SelectedMaterialExportFormat = _materialExportFormatSnapshot;
         SelectedTextureExportFormat = _textureExportFormatSnapshot;
         CriwareDecryptionKey = _criwareDecryptionKey;
-        OnDemandTimeout = _onDemandTimeout;
         SelectedAesReload = UserSettings.Default.AesReload;
         SelectedDiscordRpc = UserSettings.Default.DiscordRpc;
 
@@ -323,7 +316,6 @@ public class SettingsViewModel : ViewModel
         UserSettings.Default.CurrentDir.Versioning.Options = SelectedOptions;
         UserSettings.Default.CurrentDir.Versioning.MapStructTypes = SelectedMapStructTypes;
         UserSettings.Default.CurrentDir.CriwareDecryptionKey = CriwareDecryptionKey;
-        UserSettings.Default.CurrentDir.OnDemandTimeout = OnDemandTimeout;
         
         UserSettings.Default.AssetLanguage = SelectedAssetLanguage;
         UserSettings.Default.CompressedAudioMode = SelectedCompressedAudio;

--- a/FModel/ViewModels/SettingsViewModel.cs
+++ b/FModel/ViewModels/SettingsViewModel.cs
@@ -198,7 +198,6 @@ public class SettingsViewModel : ViewModel
     private string _codeSnapshot;
     private string _modelSnapshot;
     private string _gameSnapshot;
-    private int _httpRequestTimeout;
     private ETexturePlatform _uePlatformSnapshot;
     private EGame _ueGameSnapshot;
     private IList<FCustomVersion> _customVersionsSnapshot;
@@ -232,7 +231,6 @@ public class SettingsViewModel : ViewModel
         _codeSnapshot = UserSettings.Default.CodeDirectory;
         _modelSnapshot = UserSettings.Default.ModelDirectory;
         _gameSnapshot = UserSettings.Default.GameDirectory;
-        _httpRequestTimeout = UserSettings.Default.HttpRequestTimeout;
         _uePlatformSnapshot = UserSettings.Default.CurrentDir.TexturePlatform;
         _ueGameSnapshot = UserSettings.Default.CurrentDir.UeVersion;
         _customVersionsSnapshot = UserSettings.Default.CurrentDir.Versioning.CustomVersions;

--- a/FModel/Views/SettingsView.xaml
+++ b/FModel/Views/SettingsView.xaml
@@ -44,6 +44,7 @@
                         <RowDefinition Height="Auto" />
                         <RowDefinition Height="Auto" />
                         <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
                     </Grid.RowDefinitions>
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="Auto" />
@@ -267,6 +268,28 @@
                              TextAlignment="Right"
                              TextChanged="CriwareKeyBox_TextChanged"
                              Loaded="CriwareKeyBox_Loaded"/>
+
+
+                    <TextBlock Grid.Row="21"
+                               Grid.Column="0"
+                               Text="OnDemand Timeout"
+                               VerticalAlignment="Center"
+                               Margin="0 0 0 10" />
+
+                    <TextBox x:Name="OnDemandTimeoutBox"
+                             Grid.Row="21"
+                             Grid.Column="2"
+                             Grid.ColumnSpan="5"
+                             Margin="0 5 0 10"
+                             VerticalAlignment="Center"
+                             VerticalContentAlignment="Center"
+                             MaxLength="10"
+                             ToolTip="Maximum time in seconds to wait for on-demand downloads to complete before aborting the request."
+                             TextAlignment="Right"
+                             PreviewTextInput="OnDemandTimeout_PreviewTextInput"
+                             DataObject.Pasting="OnDemandTimeout_Pasting"
+                             Loaded="OnDemandTimeout_Loaded"
+                             TextChanged="OnDemandTimeout_TextChanged"/>
 
                 </Grid>
             </DataTemplate>

--- a/FModel/Views/SettingsView.xaml
+++ b/FModel/Views/SettingsView.xaml
@@ -272,11 +272,11 @@
 
                     <TextBlock Grid.Row="21"
                                Grid.Column="0"
-                               Text="OnDemand Timeout"
+                               Text="HTTP Request Timeout"
                                VerticalAlignment="Center"
                                Margin="0 0 0 10" />
 
-                    <TextBox x:Name="OnDemandTimeoutBox"
+                    <TextBox x:Name="HttpRequestTimeoutBox"
                              Grid.Row="21"
                              Grid.Column="2"
                              Grid.ColumnSpan="5"
@@ -284,12 +284,12 @@
                              VerticalAlignment="Center"
                              VerticalContentAlignment="Center"
                              MaxLength="10"
-                             ToolTip="Maximum time in seconds to wait for on-demand downloads to complete before aborting the request."
+                             ToolTip="Maximum time in seconds to wait for HTTP requests to complete before aborting."
                              TextAlignment="Right"
-                             PreviewTextInput="OnDemandTimeout_PreviewTextInput"
-                             DataObject.Pasting="OnDemandTimeout_Pasting"
-                             Loaded="OnDemandTimeout_Loaded"
-                             TextChanged="OnDemandTimeout_TextChanged"/>
+                             PreviewTextInput="HttpRequestTimeoutBox_PreviewTextInput"
+                             DataObject.Pasting="HttpRequestTimeoutBox_Pasting"
+                             Loaded="HttpRequestTimeoutBox_Loaded"
+                             TextChanged="HttpRequestTimeoutBox_TextChanged"/>
 
                 </Grid>
             </DataTemplate>

--- a/FModel/Views/SettingsView.xaml
+++ b/FModel/Views/SettingsView.xaml
@@ -44,7 +44,6 @@
                         <RowDefinition Height="Auto" />
                         <RowDefinition Height="Auto" />
                         <RowDefinition Height="Auto" />
-                        <RowDefinition Height="Auto" />
                     </Grid.RowDefinitions>
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="Auto" />
@@ -268,29 +267,6 @@
                              TextAlignment="Right"
                              TextChanged="CriwareKeyBox_TextChanged"
                              Loaded="CriwareKeyBox_Loaded"/>
-
-
-                    <TextBlock Grid.Row="21"
-                               Grid.Column="0"
-                               Text="HTTP Request Timeout"
-                               VerticalAlignment="Center"
-                               Margin="0 0 0 10" />
-
-                    <TextBox x:Name="HttpRequestTimeoutBox"
-                             Grid.Row="21"
-                             Grid.Column="2"
-                             Grid.ColumnSpan="5"
-                             Margin="0 5 0 10"
-                             VerticalAlignment="Center"
-                             VerticalContentAlignment="Center"
-                             MaxLength="10"
-                             ToolTip="Maximum time in seconds to wait for HTTP requests to complete before aborting."
-                             TextAlignment="Right"
-                             PreviewTextInput="HttpRequestTimeoutBox_PreviewTextInput"
-                             DataObject.Pasting="HttpRequestTimeoutBox_Pasting"
-                             Loaded="HttpRequestTimeoutBox_Loaded"
-                             TextChanged="HttpRequestTimeoutBox_TextChanged"/>
-
                 </Grid>
             </DataTemplate>
             <DataTemplate x:Key="CreatorTemplate">

--- a/FModel/Views/SettingsView.xaml.cs
+++ b/FModel/Views/SettingsView.xaml.cs
@@ -62,6 +62,8 @@ public partial class SettingsView
 
         _applicationView.CUE4Parse.Provider.ReadScriptData = UserSettings.Default.ReadScriptData;
         _applicationView.CUE4Parse.Provider.ReadShaderMaps = UserSettings.Default.ReadShaderMaps;
+
+        UserSettings.Save();
     }
 
     private void OnBrowseOutput(object sender, RoutedEventArgs e)
@@ -75,6 +77,7 @@ public partial class SettingsView
         UserSettings.Default.PropertiesDirectory = path;
         UserSettings.Default.TextureDirectory = path;
         UserSettings.Default.AudioDirectory = path;
+        UserSettings.Default.CodeDirectory = path;
     }
 
     private void OnBrowseDirectories(object sender, RoutedEventArgs e)
@@ -273,34 +276,35 @@ public partial class SettingsView
         Process.Start(new ProcessStartInfo(hyperlink.NavigateUri.AbsoluteUri) { UseShellExecute = true });
     }
 
-    private void OnDemandTimeout_Loaded(object sender, RoutedEventArgs e)
+    private void HttpRequestTimeoutBox_Loaded(object sender, RoutedEventArgs e)
     {
         if (sender is not TextBox textBox)
             return;
-        textBox.Text = _applicationView.SettingsView.OnDemandTimeout.ToString();
+        textBox.Text = UserSettings.Default.HttpRequestTimeout.ToString();
     }
 
-    private void OnDemandTimeout_TextChanged(object sender, TextChangedEventArgs e)
+    private void HttpRequestTimeoutBox_TextChanged(object sender, TextChangedEventArgs e)
     {
         if (sender is not TextBox textBox)
             return;
 
         string input = textBox.Text?.Trim() ?? string.Empty;
+
         if (string.IsNullOrEmpty(input))
             return;
 
-        if (uint.TryParse(input, out uint seconds))
-            _applicationView.SettingsView.OnDemandTimeout = seconds;
+        if (int.TryParse(input, out int seconds))
+            UserSettings.Default.HttpRequestTimeout = seconds;
         else
-            textBox.Text = uint.MaxValue.ToString();
+            textBox.Text = int.MaxValue.ToString();
     }
 
-    private void OnDemandTimeout_PreviewTextInput(object sender, TextCompositionEventArgs e)
+    private void HttpRequestTimeoutBox_PreviewTextInput(object sender, TextCompositionEventArgs e)
     {
         e.Handled = !e.Text.All(char.IsDigit);
     }
 
-    private void OnDemandTimeout_Pasting(object sender, DataObjectPastingEventArgs e)
+    private void HttpRequestTimeoutBox_Pasting(object sender, DataObjectPastingEventArgs e)
     {
         if (e.DataObject.GetDataPresent(typeof(string)))
         {

--- a/FModel/Views/SettingsView.xaml.cs
+++ b/FModel/Views/SettingsView.xaml.cs
@@ -275,46 +275,4 @@ public partial class SettingsView
 
         Process.Start(new ProcessStartInfo(hyperlink.NavigateUri.AbsoluteUri) { UseShellExecute = true });
     }
-
-    private void HttpRequestTimeoutBox_Loaded(object sender, RoutedEventArgs e)
-    {
-        if (sender is not TextBox textBox)
-            return;
-        textBox.Text = UserSettings.Default.HttpRequestTimeout.ToString();
-    }
-
-    private void HttpRequestTimeoutBox_TextChanged(object sender, TextChangedEventArgs e)
-    {
-        if (sender is not TextBox textBox)
-            return;
-
-        string input = textBox.Text?.Trim() ?? string.Empty;
-
-        if (string.IsNullOrEmpty(input))
-            return;
-
-        if (int.TryParse(input, out int seconds))
-            UserSettings.Default.HttpRequestTimeout = seconds;
-        else
-            textBox.Text = int.MaxValue.ToString();
-    }
-
-    private void HttpRequestTimeoutBox_PreviewTextInput(object sender, TextCompositionEventArgs e)
-    {
-        e.Handled = !e.Text.All(char.IsDigit);
-    }
-
-    private void HttpRequestTimeoutBox_Pasting(object sender, DataObjectPastingEventArgs e)
-    {
-        if (e.DataObject.GetDataPresent(typeof(string)))
-        {
-            var text = (string)e.DataObject.GetData(typeof(string));
-            if (!text.All(char.IsDigit))
-                e.CancelCommand();
-        }
-        else
-        {
-            e.CancelCommand();
-        }
-    }
 }

--- a/FModel/Views/SettingsView.xaml.cs
+++ b/FModel/Views/SettingsView.xaml.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Documents;
+using System.Windows.Input;
 using FModel.Services;
 using FModel.Settings;
 using FModel.ViewModels;
@@ -61,8 +62,6 @@ public partial class SettingsView
 
         _applicationView.CUE4Parse.Provider.ReadScriptData = UserSettings.Default.ReadScriptData;
         _applicationView.CUE4Parse.Provider.ReadShaderMaps = UserSettings.Default.ReadShaderMaps;
-
-        UserSettings.Save();
     }
 
     private void OnBrowseOutput(object sender, RoutedEventArgs e)
@@ -76,7 +75,6 @@ public partial class SettingsView
         UserSettings.Default.PropertiesDirectory = path;
         UserSettings.Default.TextureDirectory = path;
         UserSettings.Default.AudioDirectory = path;
-        UserSettings.Default.CodeDirectory = path;
     }
 
     private void OnBrowseDirectories(object sender, RoutedEventArgs e)
@@ -273,5 +271,46 @@ public partial class SettingsView
             return;
 
         Process.Start(new ProcessStartInfo(hyperlink.NavigateUri.AbsoluteUri) { UseShellExecute = true });
+    }
+
+    private void OnDemandTimeout_Loaded(object sender, RoutedEventArgs e)
+    {
+        if (sender is not TextBox textBox)
+            return;
+        textBox.Text = _applicationView.SettingsView.OnDemandTimeout.ToString();
+    }
+
+    private void OnDemandTimeout_TextChanged(object sender, TextChangedEventArgs e)
+    {
+        if (sender is not TextBox textBox)
+            return;
+
+        string input = textBox.Text?.Trim() ?? string.Empty;
+        if (string.IsNullOrEmpty(input))
+            return;
+
+        if (uint.TryParse(input, out uint seconds))
+            _applicationView.SettingsView.OnDemandTimeout = seconds;
+        else
+            textBox.Text = uint.MaxValue.ToString();
+    }
+
+    private void OnDemandTimeout_PreviewTextInput(object sender, TextCompositionEventArgs e)
+    {
+        e.Handled = !e.Text.All(char.IsDigit);
+    }
+
+    private void OnDemandTimeout_Pasting(object sender, DataObjectPastingEventArgs e)
+    {
+        if (e.DataObject.GetDataPresent(typeof(string)))
+        {
+            var text = (string)e.DataObject.GetData(typeof(string));
+            if (!text.All(char.IsDigit))
+                e.CancelCommand();
+        }
+        else
+        {
+            e.CancelCommand();
+        }
     }
 }


### PR DESCRIPTION
The 30 seconds timeout was insufficient for large on-demand downloads.
Timeout is now configurable via settings.