### PR TITLE
Support key_manifest in Aion2 parsing

### DIFF
--- a/FModel/ViewModels/CUE4ParseViewModel.cs
+++ b/FModel/ViewModels/CUE4ParseViewModel.cs
@@ -1095,6 +1095,11 @@ public class CUE4ParseViewModel : ViewModel
                 var l10nData = new FAion2L10NFile(entry, Provider);
                 TabControl.SelectedTab.SetDocumentText(JsonConvert.SerializeObject(l10nData, Formatting.Indented), saveProperties, updateUi);
             }
+            else if (entry.NameWithoutExtension.Equals("key_manifest"))
+            {
+                var records = Aion2TextLocalizationResource.ReadKeyManifest(entry.Read());
+                TabControl.SelectedTab.SetDocumentText(JsonConvert.SerializeObject(new { Version = 2, RecordCount = records.Count, Records = records }, Formatting.Indented), saveProperties, updateUi);
+            }
             else
             {
                 FAion2DataFile datfile = entry.NameWithoutExtension switch


### PR DESCRIPTION
Add handling for entries named "key_manifest" in CUE4ParseViewModel. The code reads records using Aion2TextLocalizationResource.ReadKeyManifest(entry.Read()) and sets the tab document to a JSON object containing Version=2, RecordCount and Records, using the existing saveProperties/updateUi flow. This enables viewing key_manifest contents in the UI.