### PR TITLE
Add optional .o.uasset editor-only data merging setting

### DIFF
--- a/FModel/Settings/UserSettings.cs
+++ b/FModel/Settings/UserSettings.cs
@@ -282,6 +282,13 @@ namespace FModel.Settings
             set => SetProperty(ref _convertAudioOnBulkExport, value);
         }
 
+        private bool _mergeEditorOnlyDataExports = true;
+        public bool MergeEditorOnlyDataExports
+        {
+            get => _mergeEditorOnlyDataExports;
+            set => SetProperty(ref _mergeEditorOnlyDataExports, value);
+        }
+
         private bool _decompileLua;
         public bool DecompileLua
         {

--- a/FModel/ViewModels/CUE4ParseViewModel.cs
+++ b/FModel/ViewModels/CUE4ParseViewModel.cs
@@ -676,7 +676,34 @@ public class CUE4ParseViewModel : ViewModel
 
                 if (saveProperties || updateUi)
                 {
-                    TabControl.SelectedTab.SetDocumentText(JsonConvert.SerializeObject(result.GetDisplayData(saveProperties), Formatting.Indented), saveProperties, updateUi);
+                    var displayData = result.GetDisplayData(saveProperties);
+
+                    if (UserSettings.Default.MergeEditorOnlyDataExports && Provider.TryLoadPackage(entry.Path.SubstringBefore('.') + ".o.uasset", out var editorAsset))
+                    {
+                        var pkg = Provider.LoadPackage(entry.Path);
+                        var exports = pkg.GetExports().ToArray();
+                        var finalExports = new List<UObject>(exports);
+                        var editorOnlyDataExports = new HashSet<UObject>();
+
+                        foreach (var export in exports)
+                        {
+                            var editorData = editorAsset.GetExportOrNull(export.Name + "EditorOnlyData");
+                            if (editorData == null)
+                                continue;
+
+                            export.Properties.AddRange(editorData.Properties);
+                            editorOnlyDataExports.Add(editorData);
+                        }
+
+                        if (editorOnlyDataExports.Count > 0)
+                        {
+                            finalExports.AddRange(editorAsset.GetExports().Where(editorExport => !editorOnlyDataExports.Contains(editorExport)));
+                        }
+
+                        displayData = finalExports;
+                    }
+
+                    TabControl.SelectedTab.SetDocumentText(JsonConvert.SerializeObject(displayData, Formatting.Indented), saveProperties, updateUi);
                     if (saveProperties) break; // do not search for viewable exports if we are dealing with jsons
                 }
 

--- a/FModel/Views/SettingsView.xaml
+++ b/FModel/Views/SettingsView.xaml
@@ -260,12 +260,24 @@
 
                     <TextBlock Grid.Row="21"
                                Grid.Column="0"
+                               Text="Merge Editor-Only Data (.o.uasset)"
+                               VerticalAlignment="Center"
+                               ToolTip="Reads .o.uasset packages and merges their editor-only data into the parent asset. Useful for JSON-based asset export workflows"
+                               Margin="0 0 0 5" />
+                    <CheckBox Grid.Row="21"
+                              Grid.Column="2"
+                              Content="{Binding IsChecked, RelativeSource={RelativeSource Self}, Converter={x:Static converters:BoolToToggleConverter.Instance}}"
+                              IsChecked="{Binding MergeEditorOnlyDataExports, Source={x:Static local:Settings.UserSettings.Default}, Mode=TwoWay}"
+                              Margin="0 5 0 10"
+                              Style="{DynamicResource {x:Static adonisUi:Styles.ToggleSwitch}}" />
+
+                    <TextBlock Grid.Row="22"
+                               Grid.Column="0"
                                Text="CRIWARE Decryption Key"
                                VerticalAlignment="Center"
                                Margin="0 0 0 10" />
-
                     <TextBox x:Name="CriwareKeyBox"
-                             Grid.Row="21"
+                             Grid.Row="22"
                              Grid.Column="2"
                              Grid.ColumnSpan="5"
                              Margin="0 5 0 10"
@@ -275,20 +287,7 @@
                              ToolTip="Enter decryption key in numeric or hexadecimal format (valid key is up to 20 digits or 8 bytes long)"
                              TextAlignment="Right"
                              TextChanged="CriwareKeyBox_TextChanged"
-                             Loaded="CriwareKeyBox_Loaded"/>
-
-                    <TextBlock Grid.Row="22"
-                               Grid.Column="0"
-                               Text="Merge Editor-Only Data (.o.uasset)"
-                               VerticalAlignment="Center"
-                               ToolTip="Reads .o.uasset packages and merges their editor-only data into the parent asset. Useful for JSON-based asset export workflows"
-                               Margin="0 0 0 5" />
-                    <CheckBox Grid.Row="22"
-                              Grid.Column="2"
-                              Content="{Binding IsChecked, RelativeSource={RelativeSource Self}, Converter={x:Static converters:BoolToToggleConverter.Instance}}"
-                              IsChecked="{Binding MergeEditorOnlyDataExports, Source={x:Static local:Settings.UserSettings.Default}, Mode=TwoWay}"
-                              Margin="0 5 0 10"
-                              Style="{DynamicResource {x:Static adonisUi:Styles.ToggleSwitch}}" />
+                             Loaded="CriwareKeyBox_Loaded" />
                 </Grid>
             </DataTemplate>
             <DataTemplate x:Key="CreatorTemplate">

--- a/FModel/Views/SettingsView.xaml
+++ b/FModel/Views/SettingsView.xaml
@@ -46,6 +46,7 @@
                         <RowDefinition Height="Auto" />
                         <RowDefinition Height="Auto" />
                         <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
                     </Grid.RowDefinitions>
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="Auto" />
@@ -276,6 +277,18 @@
                              TextChanged="CriwareKeyBox_TextChanged"
                              Loaded="CriwareKeyBox_Loaded"/>
 
+                    <TextBlock Grid.Row="22"
+                               Grid.Column="0"
+                               Text="Merge Editor-Only Data (.o.uasset)"
+                               VerticalAlignment="Center"
+                               ToolTip="Reads .o.uasset packages and merges their editor-only data into the parent asset. Useful for JSON-based asset export workflows"
+                               Margin="0 0 0 5" />
+                    <CheckBox Grid.Row="22"
+                              Grid.Column="2"
+                              Content="{Binding IsChecked, RelativeSource={RelativeSource Self}, Converter={x:Static converters:BoolToToggleConverter.Instance}}"
+                              IsChecked="{Binding MergeEditorOnlyDataExports, Source={x:Static local:Settings.UserSettings.Default}, Mode=TwoWay}"
+                              Margin="0 5 0 10"
+                              Style="{DynamicResource {x:Static adonisUi:Styles.ToggleSwitch}}" />
                 </Grid>
             </DataTemplate>
             <DataTemplate x:Key="CreatorTemplate">


### PR DESCRIPTION
# Summary
Adds an optional setting to merge editor-only data from matching `.o.uasset` packages into the exported asset data.

When enabled, FModel checks for a matching `.o.uasset` package and merges `EditorOnlyData` properties into the corresponding parent exports before serializing display/export data.

## Default Behavior
The setting currently defaults to enabled so editor-only data is preserved automatically when available.

I'm open to making it disabled by default instead if that better fits FModel's expected default behavior.

## Notes
* No behavior change when the matching `.o.uasset` package does not exist.
* Keeps the existing package/view/export flow unchanged outside this optional path.
* Primarily relevant to Fortnite, where editor-only data may be split into matching `.o.uasset` companion packages.
* Useful for material-related JSON export workflows and downstream tooling that needs complete editor-only asset data, such as [JsonAsAsset](https://github.com/JsonAsAsset/JsonAsAsset).

    In our case, this previously required maintaining a custom FModel build so `.o.uasset` editor-only data could be preserved during export.

## Video

https://github.com/user-attachments/assets/98913cee-e638-41c8-936e-db92368afef0