### PR TITLE
Fix backup compare + package count

### DIFF
--- a/FModel/ViewModels/AssetsFolderViewModel.cs
+++ b/FModel/ViewModels/AssetsFolderViewModel.cs
@@ -211,7 +211,7 @@ public class AssetsFolderViewModel
 
     public void BulkPopulate(IReadOnlyCollection<GameFile> entries)
     {
-        if (entries == null || entries.Count == 0)
+        if (entries == null)
             return;
 
         Application.Current.Dispatcher.Invoke(() =>

--- a/FModel/ViewModels/BackupManagerViewModel.cs
+++ b/FModel/ViewModels/BackupManagerViewModel.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Data;
 using CUE4Parse.FileProvider.Objects;
+using CUE4Parse.UE4.VirtualFileSystem;
 using FModel.Framework;
 using FModel.Services;
 using FModel.Settings;
@@ -21,6 +22,7 @@ namespace FModel.ViewModels;
 public class BackupManagerViewModel : ViewModel
 {
     public const uint FBKP_MAGIC = 0x504B4246;
+    public const string FBKP_NONVFS = "nonvfs";
 
     private ThreadWorkerViewModel _threadWorkerView => ApplicationService.ThreadWorkerView;
     private ApiEndpointViewModel _apiEndpointView => ApplicationService.ApiEndpointView;
@@ -81,6 +83,11 @@ public class BackupManagerViewModel : ViewModel
                 writer.Write(asset.Size);
                 writer.Write(asset.IsEncrypted);
                 writer.Write(asset.Path);
+
+                if (asset is VfsEntry vfsAsset)
+                    writer.Write(vfsAsset.Vfs.Name);
+                else
+                    writer.Write(FBKP_NONVFS);
             }
 
             SaveCheck(fullPath, fileName, "created", "create");
@@ -122,6 +129,7 @@ public enum EBackupVersion : byte
     BeforeVersionWasAdded = 0,
     Initial,
     PerfectPath, // no more leading slash and ToLower
+    Vfs, // added vfs name
 
     LatestPlusOne,
     Latest = LatestPlusOne - 1

--- a/FModel/ViewModels/Commands/LoadCommand.cs
+++ b/FModel/ViewModels/Commands/LoadCommand.cs
@@ -229,8 +229,14 @@ public class LoadCommand : ViewModelCommand<LoadingModesViewModel>
                         cancellationToken.ThrowIfCancellationRequested();
 
                         archive.Position += sizeof(long) + sizeof(byte);
-                        var fullPath = archive.ReadString();
+                        var fullPath = archive.ReadFUtf8String(archive.Read7BitEncodedInt());
                         if (version < EBackupVersion.PerfectPath) fullPath = fullPath[1..];
+                        if (version >= EBackupVersion.Vfs)
+                        {
+                            //readint advances Position, directly doing += overrides it
+                            var length = archive.Read7BitEncodedInt();
+                            archive.Position += length;
+                        }
 
                         paths.Add(fullPath);
                     }
@@ -276,10 +282,11 @@ public class LoadCommand : ViewModelCommand<LoadingModesViewModel>
 
                         var uncompressedSize = archive.Read<long>();
                         var isEncrypted = archive.ReadFlag();
-                        var fullPath = archive.ReadString();
+                        var fullPath = archive.ReadFUtf8String(archive.Read7BitEncodedInt());
                         if (version < EBackupVersion.PerfectPath) fullPath = fullPath[1..];
+                        var vfsName = version >= EBackupVersion.Vfs ? archive.ReadString() : null;
 
-                        AddEntry(fullPath, uncompressedSize, isEncrypted, entries);
+                        AddEntry(fullPath, uncompressedSize, isEncrypted, entries, vfsName);
                     }
                 }
                 break;
@@ -289,10 +296,15 @@ public class LoadCommand : ViewModelCommand<LoadingModesViewModel>
         return entries;
     }
 
-    private void AddEntry(string path, long uncompressedSize, bool isEncrypted, List<GameFile> entries)
+    private void AddEntry(string path, long uncompressedSize, bool isEncrypted, List<GameFile> entries, string vfsName = null)
     {
-        if (!_applicationView.CUE4Parse.Provider.Files.TryGetValue(path, out var asset) ||
-            asset.IsUePackagePayload || asset.Size == uncompressedSize && asset.IsEncrypted == isEncrypted)
+        if (!_applicationView.CUE4Parse.Provider.Files.TryGetValues(path, out var assets))
+            return;
+
+        GameFile asset = vfsName is null || vfsName == BackupManagerViewModel.FBKP_NONVFS ?
+            assets[0] : assets.Find(x => (x as VfsEntry).Vfs.Name == vfsName);
+
+        if (asset is null || asset.IsUePackagePayload || asset.Size == uncompressedSize && asset.IsEncrypted == isEncrypted)
             return;
 
         entries.Add(asset);


### PR DESCRIPTION
- Changed reading strings to reading UTF-8 strings because when a path contained non-ASCII characters (it shouldn't, but oh well), it'd be read incorrectly.

- Added VFS name to each asset in the backup file to differentiate them from patch files when reading for All (Modified). Since they have the same path but exist twice, `TryGetValue` would return the same asset both times, so one of them would always be listed.

- Removed check for 0 entries because the search window wouldn't update loaded package count when there were none.